### PR TITLE
Add mobile-first Web3 AR cube prototype app

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,7 @@ Captured metrics:
 Metrics summary can be exported to CSV. This way multiple configuration can be scripted over. CSV file can be imported to Google Sheets/Excel or Jupyter for further analysis.
 
 See [`llm_bench`](llm_bench) folder for detailed usage.
+
+## AR web app prototype
+
+A mobile-oriented Web3 + Three.js AR cube prototype is available in [`ar_web3_cube_app`](ar_web3_cube_app).

--- a/ar_web3_cube_app/README.md
+++ b/ar_web3_cube_app/README.md
@@ -1,0 +1,37 @@
+# Web3 AR Cube Mobile Web App
+
+This is a mobile-first web app prototype that combines:
+- **web3.js wallet connection** (MetaMask mobile or compatible wallet browser)
+- **3D cube scene** using Three.js
+- **AR session request** using WebXR where available
+- **Touch gesture fallback** for iPhone/mobile browsers that do not support immersive WebXR AR
+
+## Features
+
+- Connect Ethereum wallet via `eth_requestAccounts`
+- Launch AR session (`immersive-ar`) when supported
+- Drag on-screen to rotate and move the cube in fallback mode
+- Experimental hand-tracking interaction in AR mode when browser/runtime exposes hand joints
+
+## Run locally
+
+From repository root:
+
+```bash
+cd ar_web3_cube_app
+python3 -m http.server 8080
+```
+
+Open on your device/browser:
+
+- Local desktop test: `http://localhost:8080`
+- iPhone test on same Wi-Fi: `http://<your-computer-ip>:8080`
+
+## iPhone compatibility note
+
+Safari on iPhone currently has limited support for full WebXR immersive AR and hand tracking. For most iPhone setups this app will run in **3D fallback mode** (non-AR) with touch manipulation.
+
+For true iPhone browser-based AR, teams often use alternatives such as:
+- USDZ + AR Quick Look experiences
+- Native app wrappers (ARKit)
+- Commercial web AR SDKs with custom tracking pipelines

--- a/ar_web3_cube_app/app.js
+++ b/ar_web3_cube_app/app.js
@@ -1,0 +1,190 @@
+import * as THREE from "https://unpkg.com/three@0.164.1/build/three.module.js";
+import { ARButton } from "https://unpkg.com/three@0.164.1/examples/jsm/webxr/ARButton.js";
+
+const statusEl = document.getElementById("status");
+const walletAddressEl = document.getElementById("wallet-address");
+const connectWalletButton = document.getElementById("connect-wallet");
+const startArButton = document.getElementById("start-ar");
+const canvas = document.getElementById("scene");
+
+let scene;
+let camera;
+let renderer;
+let cube;
+let ground;
+let web3;
+
+let isDragging = false;
+const dragStart = new THREE.Vector2();
+
+initScene();
+bindWallet();
+bindTouchManipulation();
+
+async function initScene() {
+  scene = new THREE.Scene();
+
+  camera = new THREE.PerspectiveCamera(70, window.innerWidth / window.innerHeight, 0.01, 30);
+  camera.position.set(0, 0.8, 2);
+
+  renderer = new THREE.WebGLRenderer({
+    canvas,
+    antialias: true,
+    alpha: true,
+  });
+  renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+  renderer.setSize(window.innerWidth, window.innerHeight);
+  renderer.xr.enabled = true;
+
+  const hemi = new THREE.HemisphereLight(0xffffff, 0x445577, 1.2);
+  scene.add(hemi);
+
+  const dir = new THREE.DirectionalLight(0xffffff, 1);
+  dir.position.set(1, 3, 2);
+  scene.add(dir);
+
+  const geometry = new THREE.BoxGeometry(0.2, 0.2, 0.2);
+  const material = new THREE.MeshStandardMaterial({
+    color: 0x4d9bff,
+    roughness: 0.22,
+    metalness: 0.15,
+  });
+
+  cube = new THREE.Mesh(geometry, material);
+  cube.position.set(0, 0.1, -0.8);
+  scene.add(cube);
+
+  ground = new THREE.Mesh(
+    new THREE.PlaneGeometry(8, 8),
+    new THREE.MeshBasicMaterial({ color: 0x16233f, transparent: true, opacity: 0.35 })
+  );
+  ground.rotation.x = -Math.PI / 2;
+  ground.position.y = 0;
+  scene.add(ground);
+
+  window.addEventListener("resize", onResize);
+
+  renderer.setAnimationLoop(render);
+  status("3D preview ready. You can drag to rotate and move cube with one finger.");
+}
+
+function bindWallet() {
+  connectWalletButton.addEventListener("click", async () => {
+    try {
+      const { ethereum } = window;
+      if (!ethereum) {
+        status("No wallet detected. Open this page in MetaMask mobile browser or another Web3 wallet browser.");
+        return;
+      }
+
+      const accounts = await ethereum.request({ method: "eth_requestAccounts" });
+      web3 = new Web3(ethereum);
+      walletAddressEl.textContent = `Wallet: ${accounts[0]}`;
+      status("Wallet connected. Ready to start AR / 3D interaction.");
+    } catch (error) {
+      status(`Wallet connection failed: ${error.message}`);
+    }
+  });
+
+  startArButton.addEventListener("click", async () => {
+    const supportsWebXR = navigator.xr && (await navigator.xr.isSessionSupported("immersive-ar"));
+    if (!supportsWebXR) {
+      status("AR not supported on this browser/device. Using 3D mode fallback with touch gestures.");
+      return;
+    }
+
+    const arButton = ARButton.createButton(renderer, {
+      requiredFeatures: ["hit-test"],
+      optionalFeatures: ["hand-tracking"],
+    });
+
+    arButton.style.display = "none";
+    document.body.appendChild(arButton);
+    arButton.click();
+    status("AR session requested. Move your device to place and manipulate the cube.");
+
+    setupHandTrackingIfAvailable();
+  });
+}
+
+function bindTouchManipulation() {
+  canvas.addEventListener("pointerdown", (event) => {
+    isDragging = true;
+    dragStart.set(event.clientX, event.clientY);
+  });
+
+  canvas.addEventListener("pointermove", (event) => {
+    if (!isDragging) {
+      return;
+    }
+
+    const dx = event.clientX - dragStart.x;
+    const dy = event.clientY - dragStart.y;
+    dragStart.set(event.clientX, event.clientY);
+
+    cube.rotation.y += dx * 0.01;
+    cube.rotation.x += dy * 0.01;
+
+    const panScale = 0.0015;
+    cube.position.x += dx * panScale;
+    cube.position.y = Math.min(1.3, Math.max(0.05, cube.position.y - dy * panScale));
+  });
+
+  const endDrag = () => {
+    isDragging = false;
+  };
+
+  canvas.addEventListener("pointerup", endDrag);
+  canvas.addEventListener("pointercancel", endDrag);
+}
+
+function setupHandTrackingIfAvailable() {
+  const session = renderer.xr.getSession();
+  if (!session || !session.inputSources) {
+    return;
+  }
+
+  const tip = new THREE.Vector3();
+  const thumb = new THREE.Vector3();
+
+  renderer.setAnimationLoop((time, frame) => {
+    if (frame) {
+      for (const source of session.inputSources) {
+        if (!source.hand) {
+          continue;
+        }
+
+        const indexPose = frame.getJointPose(source.hand.get("index-finger-tip"), renderer.xr.getReferenceSpace());
+        const thumbPose = frame.getJointPose(source.hand.get("thumb-tip"), renderer.xr.getReferenceSpace());
+
+        if (indexPose && thumbPose) {
+          tip.set(indexPose.transform.position.x, indexPose.transform.position.y, indexPose.transform.position.z);
+          thumb.set(thumbPose.transform.position.x, thumbPose.transform.position.y, thumbPose.transform.position.z);
+
+          const pinchDistance = tip.distanceTo(thumb);
+          if (pinchDistance < 0.03) {
+            cube.position.lerp(tip, 0.3);
+            cube.rotation.y += 0.02;
+          }
+        }
+      }
+    }
+
+    render(time, frame);
+  });
+}
+
+function render() {
+  cube.rotation.y += 0.005;
+  renderer.render(scene, camera);
+}
+
+function onResize() {
+  camera.aspect = window.innerWidth / window.innerHeight;
+  camera.updateProjectionMatrix();
+  renderer.setSize(window.innerWidth, window.innerHeight);
+}
+
+function status(message) {
+  statusEl.textContent = message;
+}

--- a/ar_web3_cube_app/index.html
+++ b/ar_web3_cube_app/index.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, viewport-fit=cover, user-scalable=no"
+    />
+    <title>Web3 AR Cube (Mobile)</title>
+    <link rel="stylesheet" href="./styles.css" />
+  </head>
+  <body>
+    <div class="hud">
+      <h1>Web3 AR Cube</h1>
+      <p id="status">Ready</p>
+      <div class="actions">
+        <button id="connect-wallet">Connect Wallet</button>
+        <button id="start-ar">Start AR</button>
+      </div>
+      <p id="wallet-address">Wallet: not connected</p>
+      <small>
+        Tip: On iPhone Safari, WebXR support is limited. This demo includes an on-screen 3D fallback and touch controls when AR is unavailable.
+      </small>
+    </div>
+
+    <canvas id="scene"></canvas>
+
+    <script src="https://cdn.jsdelivr.net/npm/web3@4.12.1/dist/web3.min.js"></script>
+    <script type="module" src="./app.js"></script>
+  </body>
+</html>

--- a/ar_web3_cube_app/styles.css
+++ b/ar_web3_cube_app/styles.css
@@ -1,0 +1,71 @@
+:root {
+  color-scheme: dark;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  overflow: hidden;
+  background: #05080f;
+  color: #f4f7ff;
+}
+
+#scene {
+  position: fixed;
+  inset: 0;
+  width: 100vw;
+  height: 100vh;
+  touch-action: none;
+}
+
+.hud {
+  position: fixed;
+  z-index: 2;
+  top: 12px;
+  left: 12px;
+  right: 12px;
+  padding: 12px;
+  border-radius: 12px;
+  background: rgb(8 11 19 / 76%);
+  backdrop-filter: blur(6px);
+  border: 1px solid rgb(255 255 255 / 12%);
+}
+
+h1 {
+  margin: 0 0 8px;
+  font-size: 1.1rem;
+}
+
+p {
+  margin: 6px 0;
+}
+
+.actions {
+  display: flex;
+  gap: 8px;
+  margin: 8px 0;
+}
+
+button {
+  border: none;
+  border-radius: 10px;
+  padding: 10px 12px;
+  color: #0d1220;
+  background: #91b4ff;
+  font-weight: 600;
+}
+
+button:disabled {
+  opacity: 0.65;
+}
+
+small {
+  display: block;
+  opacity: 0.8;
+  line-height: 1.3;
+}


### PR DESCRIPTION
### Motivation
- Provide a mobile-oriented demo that demonstrates a Web3 wallet flow alongside a simple AR/3D interaction for rapid experimentation on phones and mobile browsers.
- Support devices without full WebXR by offering a touch-driven 3D fallback so the app is usable on iPhone Safari and other limited environments.

### Description
- Add a new prototype in `ar_web3_cube_app` containing `index.html`, `styles.css`, `app.js`, and a local `README.md` implementing a HUD, wallet/connect controls, and a full-screen Three.js canvas.
- Implement Web3 wallet connection using `eth_requestAccounts` and `web3.js` for mobile wallet browsers in `app.js`.
- Wire up WebXR AR session startup via `ARButton.createButton` requesting `immersive-ar` with optional `hand-tracking`, and provide an experimental hand-tracking loop that moves the cube on a pinch gesture.
- Implement a touch-based manipulation fallback that supports dragging to rotate and pan the cube for devices without AR support, and update the root `README.md` to reference the prototype.

### Testing
- Performed a static JS check with `node --check ar_web3_cube_app/app.js`, which completed successfully.
- Served the prototype locally via `python3 -m http.server 8080` and verified assets load in a headless browser by capturing a screenshot with Playwright, which succeeded.
- No automated unit tests were added; manual/visual validation was used for runtime behavior and compatibility notes are documented in `ar_web3_cube_app/README.md`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af83cc145c8325acb9258c3b761237)